### PR TITLE
4.0.0

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-v4.0.0alpha
+v4.0.0alpha2

--- a/client/bins/wireguard-client.py
+++ b/client/bins/wireguard-client.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# We eventually want to test tunneling for wireguard connections as well
+import os
+import subprocess
+import platform
+import getpass
+import getopt
+import sys
+
+def get_user_input():
+    username = None
+    password = None
+    cert_path = None
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "u:p:c:", ["username=", "password=", "cert_path="])
+    except getopt.GetoptError as err:
+        print(str(err))
+        sys.exit(2)
+
+    for opt, arg in opts:
+        if opt in ("-u", "--username"):
+            username = arg
+        elif opt in ("-p", "--password"):
+            password = arg
+        elif opt in ("-c", "--cert_path"):
+            cert_path = arg
+
+    if not username or  not cert_path:
+        print("Missing command line arguments, falling back to interactive input.")
+        username = input("Enter username: ")
+        password = getpass.getpass("Enter password: ")
+        cert_path = input("Enter path to the certificate: ")
+    elif not password:
+        password = getpass.getpass("Enter password: ")
+    return username, password, cert_path
+
+def establish_wireguard_connection(username, password, cert_path):
+    system = platform.system().lower()
+    wg_command = ""
+
+    if system == "windows":
+        wg_command = f'wireguard /installtunnelservice "{cert_path}"'
+    elif system == "linux" or system == "darwin":  # darwin is for macOS
+        wg_command = f'sudo wg-quick up "{cert_path}"'
+    else:
+        print(f"Unsupported OS: {system}")
+        return
+
+    try:
+        env = os.environ.copy()
+        env["WG_USER"] = username
+        env["WG_PASS"] = password
+        subprocess.run(wg_command, shell=True, check=True, env=env)
+        print("WireGuard connection established successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to establish WireGuard connection: {e}")
+
+if __name__ == "__main__":
+    username, password, cert_path = get_user_input()
+    establish_wireguard_connection(username, password, cert_path)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -56,6 +56,14 @@ ENV HEALTHCHECK_INTERVAL="10"
 # Results drop off location
 ENV RESULTS_DIR="/var/www/waddleperf"
 ENV RESULTS_FILE="results.json"
+#  Nginx for results and PEM
+EXPOSE 8080 
+# Nginx for results and PEM
+EXPOSE 443 
+# iPerf Server
+EXPOSE 5201 
+# SpeedTest Web UI
+EXPOSE 80 
 RUN chown -R www-data:www-data /var/lib/nginx && chown -R www-data:www-data /usr/share/nginx
 # Switch to non-root user
 USER www-data

--- a/server/templates/nginx.j2
+++ b/server/templates/nginx.j2
@@ -8,7 +8,7 @@ server {
         location / {
                 # First attempt to serve request as file, then
                 # as directory, then fall back to displaying a 404.
-                autoindex on;
+                #autoindex on;
                 try_files $uri $uri/ =404;
         }
 

--- a/server/templates/nginx.j2
+++ b/server/templates/nginx.j2
@@ -1,23 +1,8 @@
 server {
-        listen 8080 default_server;
-        listen [::]:8080 default_server;
-        root /var/www/{{ app.title }};
-        # Add index.php to the list if you are using PHP
-        #index index.html index.htm index.nginx-debian.html;
-        server_name _;
-        location / {
-                # First attempt to serve request as file, then
-                # as directory, then fall back to displaying a 404.
-                #autoindex on;
-                try_files $uri $uri/ =404;
-        }
-
-}
-server {
         server_name _ ;
-        listen 80 default_server reuseport;
-        listen [::]:80 default_server reuseport;
-        root /var/www/speedtest;
+        listen {{ web.port }} default_server reuseport;
+        listen [::]:{{ web.port }} default_server reuseport;
+        root /var/www;
         index index.html;
         client_max_body_size 35m;
         error_page 405 =200 $uri;
@@ -41,8 +26,12 @@ server {
             try_files $uri =404;
             break;
         }
+        location / {
+            // redirect to /speedtest 
+            return 301 /speedtest/;
+        }
 
-        location / {            
+        location /speedtest {            
             add_header 'Access-Control-Allow-Origin' "*" always;
             add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
@@ -80,4 +69,11 @@ server {
         gzip_http_version 1.1;
         gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript image/svg+xml;
     }
+            location /{{app.title}} {
+                # First attempt to serve request as file, then
+                # as directory, then fall back to displaying a 404.
+                autoindex on;
+                try_files $uri $uri/ =404;
+        }
+    
 }


### PR DESCRIPTION
Fixed a few things to make it easier to deploy and manage

## Summary by Sourcery

Update the Nginx configuration to redirect root requests to /speedtest, expose additional ports for iPerf server and SpeedTest Web UI, and introduce a WireGuard client script for establishing secure connections.

New Features:
- Add a WireGuard client script to establish secure WireGuard connections using provided credentials and certificate.

Build:
- Expose ports 8080, 443 for Nginx, 5201 for iPerf server, and 80 for SpeedTest Web UI.